### PR TITLE
fix(session): renew the access token instead of logging the user out [#CP-13] [#CP-23]

### DIFF
--- a/adapter/httpAdapter.ts
+++ b/adapter/httpAdapter.ts
@@ -1,13 +1,11 @@
 import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { AuthResponse } from '@/app/(full-page)/auth/login/interface/AuthResponse';
+import { baseConfig } from '@/adapter/httpConfig';
+import { WebEnvConst } from '@/app/webEnvConst';
+import { clearSession, readSession, refreshSession } from '@/lib/session';
 
-const baseConfig = {
-    baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
-    timeout: 10000,
-    headers: {
-        'Content-Type': 'application/json'
-    }
-};
+// Set once a request has already been replayed with a renewed token, so a
+// second 401 ends the session instead of looping.
+type RetriableRequest = InternalAxiosRequestConfig & { _retriedAfterRefresh?: boolean };
 
 const httpAdapter = axios.create(baseConfig);
 
@@ -19,13 +17,31 @@ httpAdapter.interceptors.response.use(
     (response: AxiosResponse) => {
         return response;
     },
-    (error: AxiosError) => {
+    async (error: AxiosError) => {
         const status = error.response?.status;
-        const isAuthError = status === 401 || status === 403;
+        const originalRequest = error.config as RetriableRequest | undefined;
 
-        if (isAuthError) {
-            localStorage.removeItem('authUser');
-            localStorage.removeItem('token');
+        // Only a 401 means "this access token is spent". A 403 is a role
+        // decision, and a renewed token carries exactly the same roles.
+        const canRetry =
+            status === 401 &&
+            !!originalRequest &&
+            !originalRequest._retriedAfterRefresh &&
+            originalRequest.url !== WebEnvConst.auth.login;
+
+        if (canRetry) {
+            originalRequest._retriedAfterRefresh = true;
+
+            const session = await refreshSession();
+
+            if (session?.access_token) {
+                originalRequest.headers.Authorization = `Bearer ${session.access_token}`;
+                return httpAdapter(originalRequest);
+            }
+        }
+
+        if (status === 401 || status === 403) {
+            clearSession();
 
             if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth/login')) {
                 window.location.href = '/auth/login';
@@ -39,23 +55,12 @@ httpAdapter.interceptors.response.use(
 httpAdapter.interceptors.request.use(
     (config: InternalAxiosRequestConfig) => {
 
-        if (typeof window !== 'undefined') {
-            try {
-                const authUser = localStorage.getItem('authUser');
+        const token = readSession()?.access_token;
 
-                if (authUser) {
-                    const parsedAuthUser: AuthResponse = JSON.parse(authUser);
-                    const token = parsedAuthUser.access_token;
-
-                    if (token) {
-                        config.headers.Authorization = `Bearer ${token}`;
-                    }
-                }
-            } catch {
-                // A corrupted authUser entry is dropped so the next login rewrites it.
-                localStorage.removeItem('authUser');
-            }
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
         }
+
         return config;
     }
 );

--- a/adapter/httpConfig.ts
+++ b/adapter/httpConfig.ts
@@ -1,0 +1,10 @@
+// Extracted so the session module can build its own axios instance without
+// importing httpAdapter, which would close an import cycle (httpAdapter needs
+// the session module to refresh on 401).
+export const baseConfig = {
+    baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+    timeout: 10000,
+    headers: {
+        'Content-Type': 'application/json'
+    }
+};

--- a/app/webEnvConst.ts
+++ b/app/webEnvConst.ts
@@ -1,6 +1,7 @@
 export const WebEnvConst = {
     auth: {
         login: '/auth/login',
+        refresh: '/auth/refresh',
         recover: '/auth/recover',
         verifyCode: '/auth/verify-code',
         changePassword: '/auth/change-password',

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,97 @@
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+import { baseConfig } from '@/adapter/httpConfig';
+import { WebEnvConst } from '@/app/webEnvConst';
+import { AuthResponse } from '@/app/(full-page)/auth/login/interface/AuthResponse';
+
+const STORAGE_KEY = 'authUser';
+
+// Bare instance on purpose: the refresh call must not travel through the
+// interceptors that trigger it, or a rejected refresh would try to refresh
+// itself.
+const refreshClient = axios.create(baseConfig);
+
+export const readSession = (): AuthResponse | null => {
+    if (typeof window === 'undefined') return null;
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+        return JSON.parse(raw) as AuthResponse;
+    } catch {
+        // A corrupted entry is dropped so the next login rewrites it.
+        localStorage.removeItem(STORAGE_KEY);
+        return null;
+    }
+};
+
+export const writeSession = (session: AuthResponse): void => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+};
+
+export const clearSession = (): void => {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(STORAGE_KEY);
+};
+
+/**
+ * True when the JWT is missing, unreadable or past its `exp`.
+ * An unreadable token counts as expired: there is nothing useful to do with it.
+ */
+export const isTokenExpired = (token?: string): boolean => {
+    if (!token) return true;
+
+    try {
+        const { exp } = jwtDecode<{ exp?: number }>(token);
+        if (!exp) return true;
+        return exp < Date.now() / 1000;
+    } catch {
+        return true;
+    }
+};
+
+let inFlightRefresh: Promise<AuthResponse | null> | null = null;
+
+const performRefresh = async (): Promise<AuthResponse | null> => {
+    const session = readSession();
+
+    // Nothing to trade in, and an expired refresh token is a real logout.
+    if (!session?.refresh_token || isTokenExpired(session.refresh_token)) {
+        return null;
+    }
+
+    try {
+        const { data } = await refreshClient.post<AuthResponse>(WebEnvConst.auth.refresh, {
+            refreshAuthToken: session.refresh_token
+        });
+
+        if (!data?.access_token) return null;
+
+        writeSession(data);
+        return data;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Exchanges the stored refresh token for a fresh pair and persists it.
+ * Resolves to null when the session cannot be renewed, which the callers treat
+ * as a logout.
+ *
+ * The API rotates the refresh token on every call and only keeps the hash of
+ * the last one it issued, so two concurrent refreshes would leave one caller
+ * holding a token the server has already replaced. Every caller therefore waits
+ * on the same in-flight request.
+ */
+export const refreshSession = (): Promise<AuthResponse | null> => {
+    if (!inFlightRefresh) {
+        inFlightRefresh = performRefresh().finally(() => {
+            inFlightRefresh = null;
+        });
+    }
+
+    return inFlightRefresh;
+};

--- a/lib/withAuth.tsx
+++ b/lib/withAuth.tsx
@@ -2,19 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useEffect, useState } from 'react';
-import { jwtDecode } from 'jwt-decode';
-import { AuthResponse } from '@/app/(full-page)/auth/login/interface/AuthResponse';
 import { ProgressSpinner } from 'primereact/progressspinner';
-
-interface JwtPayload {
-    roles: string;
-    uuid: string;
-    email: string;
-    name: string;
-    lastName: string;
-    iat: number;
-    exp: number;
-}
+import { clearSession, isTokenExpired, readSession, refreshSession } from '@/lib/session';
 
 const withAuth = <P extends object>(WrappedComponent: React.ComponentType<P>): React.FC<P> => {
     const ComponentWithAuth: React.FC<P> = (props: P) => {
@@ -22,53 +11,42 @@ const withAuth = <P extends object>(WrappedComponent: React.ComponentType<P>): R
         const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
         const [isLoading, setIsLoading] = useState(true);
 
-        const checkAuth = useCallback(() => {
-            try {
-                const authUser = localStorage.getItem('authUser');
+        const resolveAuth = useCallback(async (): Promise<boolean> => {
+            const session = readSession();
 
-                if (!authUser) {
-                    setIsAuthenticated(false);
-                    setIsLoading(false);
-                    router.replace('/auth/login');
-                    return;
-                }
+            if (!session?.access_token) return false;
 
-                const parsedAuthUser: AuthResponse = JSON.parse(authUser);
-
-                if (!parsedAuthUser.access_token) {
-                    setIsAuthenticated(false);
-                    setIsLoading(false);
-                    localStorage.removeItem('authUser');
-                    router.replace('/auth/login');
-                    return;
-                }
-
-                const decodedToken: JwtPayload = jwtDecode<JwtPayload>(parsedAuthUser.access_token);
-
-                if (decodedToken.exp < Date.now() / 1000) {
-                    setIsAuthenticated(false);
-                    setIsLoading(false);
-                    localStorage.removeItem('authUser');
-                    router.replace('/auth/login');
-                    return;
-                }
-
-                setIsAuthenticated(true);
-                setIsLoading(false);
-            } catch (error) {
-                console.error('Error al verificar autenticación:', error);
-                setIsAuthenticated(false);
-                setIsLoading(false);
-                localStorage.removeItem('authUser');
-                router.replace('/auth/login');
+            // An expired access token is not the end of the session: the
+            // refresh token outlives it by weeks, so renew it here rather than
+            // bouncing the user back to the login form.
+            if (isTokenExpired(session.access_token)) {
+                return !!(await refreshSession());
             }
-        }, [router]);
+
+            return true;
+        }, []);
 
         useEffect(() => {
-            if (typeof window !== 'undefined') {
-                checkAuth();
-            }
-        }, [checkAuth]);
+            if (typeof window === 'undefined') return;
+
+            let active = true;
+
+            void resolveAuth().then((authenticated) => {
+                if (!active) return;
+
+                if (!authenticated) {
+                    clearSession();
+                    router.replace('/auth/login');
+                }
+
+                setIsAuthenticated(authenticated);
+                setIsLoading(false);
+            });
+
+            return () => {
+                active = false;
+            };
+        }, [resolveAuth, router]);
 
         // Loading con PrimeReact
         if (isLoading || isAuthenticated === null) {


### PR DESCRIPTION
**CP-13 (high, correctness): a 401 destroyed the session outright.**

The API issues a refresh token that outlives the access token by weeks, and the front-end never used it. The response interceptor wiped `authUser` and hard-redirected (`adapter/httpAdapter.ts:22-36`), and `withAuth` did the same the moment `exp` passed (`lib/withAuth.tsx:48-54`). Users were thrown back to the login form on every access-token expiry, mid-work.

Also fixes **CP-23 (low):** `localStorage.removeItem('token')` on every auth error — nothing in the codebase ever writes a `token` key.

### What changed

New `lib/session.ts` owns the session: read/write/clear, expiry check, and refresh. A 401 now replays the original request once with a renewed token; only if the refresh fails does the session end.

Three decisions worth reviewing:

- **`lib/session.ts` is a new module rather than a patch in place.** The refresh call cannot travel through the interceptors that trigger it, or a rejected refresh would try to refresh itself. And `withAuth` needs the same logic without importing `httpAdapter`, which would close an import cycle. `adapter/httpConfig.ts` exists only to break that cycle — it is the shared axios config, nothing more.
- **Refresh is single-flight.** The API rotates the refresh token on every call and stores only the hash of the last one it issued. Two concurrent refreshes would leave one caller holding a token the server has already replaced, so every caller awaits the same in-flight promise.
- **A 403 does not trigger a retry.** A 403 is a role decision, and a renewed token carries exactly the same roles. Only a 401 means "this access token is spent".

### Verification

`lib/session.ts` was transpiled and executed against a stubbed axios and localStorage: **19/19 assertions**, including:
- 3 concurrent callers → **1** network call
- a second 401 on an already-retried request ends the session instead of looping
- an expired *refresh* token is a real logout, not a retry

**Not verified:** nothing was run against the real backend or in a browser. The full login → expiry → renewal cycle is untested end to end, and is the first thing worth a manual pass.

---

**Stack:** base is `fix/cpanel-http`. Full order in `docs/audit-2026-08.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
