### PR TITLE
docs: add the audit pass 2 report

### DIFF
--- a/docs/audit-2026-08.md
+++ b/docs/audit-2026-08.md
@@ -1,0 +1,163 @@
+# Museo CPanel — Audit Report (August 2026)
+
+Read-only diagnosis first, triage second, fixes in small batches. This file is the
+report the batches reference by id. Its counterpart lives in the API repo as
+`docs/audit-2026-08.md`; the previous audit pass on this repo left no report
+committed anywhere, which is why its eight branches sat unmerged and unexplained.
+
+- **Base branch:** `develop`
+- **Toolchain note:** installs must use `npx pnpm@10`. Neither repo declares
+  `packageManager`, and the globally installed pnpm 11 disagrees with the
+  settings block of this `lockfileVersion: '9.0'` lockfile and re-resolves the
+  whole graph. pnpm 10 is a zero-diff no-op against it, which is what made the
+  dependency batches below reviewable at all (585 changed lines for next + axios
+  instead of thousands).
+
+---
+
+## 1. Findings
+
+Severity is about impact on a running deployment. Effort is S (< 1h), M (a few
+hours), L (a day or more).
+
+### 1.1 Carried over from audit pass 1 (already fixed, never merged)
+
+| id | finding | evidence | severity | type |
+|---|---|---|---|---|
+| CP-01 | `JSON.parse(localStorage.authUser)` unguarded in the menu — a corrupted entry took the whole sidebar down | `b13c864`, `layout/AppMenu.tsx` | medium | correctness |
+| CP-02 | Unused middleware setting `Access-Control-Allow-Origin: *` | `c94dc61` | high | security |
+| CP-03 | A Pages Router API handler in an App Router project — unroutable dead code | `eadbcbf` | low | debt |
+| CP-08 | `postWithoutAuth` built its own axios config instead of the shared one | `779c573` | low | debt |
+| CP-09 | A 401 redirected to the login form with no explanation to the user | `fcdae32` | medium | ux |
+| CP-10 | No security response headers at all | `e7c4d3d`, `next.config.js:3-15` | medium | security |
+| CP-11 | A debug panel shipped in the entry form | `4514cbb` | medium | debt |
+| CP-12 | Debug logging in the axios interceptors, including request bodies | `2508d2c` | medium | security |
+
+### 1.2 New in this pass
+
+| id | finding | evidence | severity | type | effort |
+|---|---|---|---|---|---|
+| CP-13 | **A 401 destroyed the session outright.** The API issues a refresh token that outlives the access token by weeks, and the front-end never used it: the response interceptor wiped `authUser` and hard-redirected, and `withAuth` did the same on `exp`. Users were thrown back to the login form on every access-token expiry | `adapter/httpAdapter.ts:22-36`, `lib/withAuth.tsx:48-54` | high | correctness | M |
+| CP-14 | `next@15.2.3` — **critical** RCE `GHSA-9qr9-h5gf-34mp` (`<15.2.6`) plus highs open until `15.5.21` (`CVE-2026-64641`, `CVE-2026-64645`, `CVE-2026-64649`) | `package.json:25` | critical | security | M |
+| CP-15 | `jspdf@2.5.x` — two criticals: `CVE-2025-68428` (`<=3.0.4`) and `CVE-2026-31938` (`<=4.2.0`), plus the `dompurify` chain `GHSA-x4vx-rjvf-j5p4` | `package.json:23` | critical | security | M |
+| CP-17 | `axios@1.7.7` — highs open until `1.16.0` (`CVE-2026-44486/87/94/96`, `CVE-2026-44488`), SSRF `CVE-2025-27152`, and the transitive critical `form-data` `CVE-2025-7783` | `package.json:18` | high | security | S |
+| CP-18 | **A hook called conditionally.** `hookData \|\| useHookCulturalHeritageProperty()` runs the hook only when the optional prop is absent, so the first caller that omits it changes the hook order mid-tree. Both files silenced the rule with `eslint-disable-next-line react-hooks/rules-of-hooks` instead of fixing it | `CulturalHeritagePropertyList.tsx:42-43`, `CulturalHeritagePropertyWizard.tsx:62-63` | high | correctness | S |
+| CP-19 | The package is still called `sakai-react` — the template it was scaffolded from | `package.json:2` | low | debt | S |
+| CP-20 | Toolchain out of step with the framework: `eslint-config-next@13.4.6` against `next@15`, `typescript@5.1.3` | `package.json:33,41` | medium | dx | S |
+| CP-22 | The README told you to `pnpm add qrcode.react` for the QR feature. That package is not used and is not declared; the code uses `react-qr-code`, which already is | `README.md:5-12` vs `package.json:31` | low | dx | S |
+| CP-23 | `localStorage.removeItem('token')` on every auth error — nothing in the codebase ever writes a `token` key | `adapter/httpAdapter.ts:28` | low | debt | S |
+| CP-25 | Dead PrimeReact promo banner in the sidebar, kept alive by CP-27 | `layout/AppMenu.tsx:83-87` | low | debt | S |
+| CP-26 | **Phantom dependency.** `layout/AppMenuitem.tsx:7` imports `react-transition-group`, which no `package.json` declares. It resolved only through an accidental hoist; `tsc` never noticed because pnpm's default `public-hoist-pattern` hoists `*types*`, so `@types/react-transition-group` was visible while the runtime package was not. Only `next build` catches it | `layout/AppMenuitem.tsx:7`, absent from `package.json` | high | correctness | S |
+| CP-27 | `(userRole === 'super Administrador') ?? <Link .../>` — `??` on a `boolean` left operand, so the right side is unreachable. TypeScript ≥5.8 rejects it outright (`TS2869`) | `layout/AppMenu.tsx:83` | low | correctness | S |
+
+---
+
+## 2. What was fixed, by batch
+
+| batch / branch | ids | verification |
+|---|---|---|
+| `fix/cpanel-http` (`2508d2c`, 8 commits) | consolidates pass 1: CP-01, 02, 03, 08, 09, 10, 11, 12 | `tsc` 0 · `next lint` 0 · `next build` 0 |
+| `fix/cpanel-session` (`0d576aa`) | CP-13, CP-23 | `lib/session.ts` transpiled and exercised against a stubbed axios/localStorage: **19/19 assertions**, including "3 concurrent callers → 1 network call" and "a second 401 on the same request ends the session instead of looping" |
+| `fix/cpanel-deps` (`6f0c975`) | CP-14, CP-17, CP-26 | next `15.2.3 → 15.5.23`, axios `^1.7.7 → ^1.19.0`, `react-transition-group@4.4.5` declared at the version primereact already resolves so it dedupes. 585-line lockfile diff, scoped to those trees |
+| `fix/cpanel-cleanup2` (`5512394`) | CP-18, CP-19, CP-20, CP-22, CP-25, CP-27 | `typescript 5.1.3 → 5.8.2` surfaced `TS2869` at `AppMenu.tsx(83,23)`; after the batch `tsc` is 0. `hookData` is now required, both `eslint-disable`s gone |
+| `deps/cpanel-jspdf-major` (`e5b675f`) | CP-15 | Own branch, as the brief requires for a MAJOR. Replayed the real call the export code makes — `new jsPDF('landscape','mm','a3')` → `addImage` → `output('arraybuffer')` — and got a **3573-byte `%PDF-` document with an A3 landscape page** out of 4.2.1 |
+
+**Final state (`deps/cpanel-jspdf-major`):** `tsc` 0 · `next lint` 0 · `next build` 0.
+
+### Advisory delta
+
+Measured with `npx pnpm@10 audit --registry https://registry.npmjs.org/`:
+
+| | critical | high | moderate | low | total |
+|---|---|---|---|---|---|
+| `fix/cpanel-http` (before) | 4 | 58 | 60 | 8 | 130 |
+| `deps/cpanel-jspdf-major` (after) | **0** | 24 | 11 | 1 | **36** |
+
+The 24 remaining highs are 2 in `xlsx` — a direct production dependency with **no
+patched version published** (see CP-16) — and 22 transitive ones in dev chains:
+`eslint` (11), `sass>immutable` (3), `next>sharp/postcss/nanoid` (5),
+`dagre>lodash` (1), `@playwright/test>playwright` (1),
+`eslint-config-next>…>picomatch` (1).
+
+### Correction to the pass-1 triage
+
+CP-14 was originally scoped as "bump to ≥15.2.6". That is wrong: 15.2.6 closes
+only the critical. Three high advisories against `next` stay open until
+**15.5.21** (`CVE-2026-64641`, `CVE-2026-64645`, `CVE-2026-64649`), so the batch
+targets 15.5.23. The report line above records the corrected target.
+
+### Design decisions worth knowing
+
+- **CP-13 introduced `lib/session.ts` rather than patching the interceptor in
+  place.** The refresh call cannot travel through the interceptors that trigger
+  it, or a rejected refresh would try to refresh itself; and `withAuth` needs the
+  same logic without importing `httpAdapter`, which would close an import cycle.
+  `adapter/httpConfig.ts` exists only to break that cycle.
+- **Refresh is single-flight on purpose.** The API rotates the refresh token on
+  every call and stores only the hash of the last one it issued. Two concurrent
+  refreshes would leave one caller holding a token the server has already
+  replaced, so every caller awaits the same in-flight promise.
+- **403 does not trigger a retry.** A 403 is a role decision, and a renewed token
+  carries exactly the same roles. Only a 401 means "this access token is spent".
+- **CP-27 was fixed by deleting the dead branch, not by converting `??` to `&&`.**
+  Converting it would have *started* rendering a PrimeReact promo banner to
+  superadmins — a behaviour change nobody asked for.
+- **CP-26 pins `4.4.5` exactly**, the version primereact already resolves, so the
+  declaration dedupes to the existing tree instead of adding a second copy.
+
+---
+
+## 3. Out of scope
+
+| id | finding | evidence | why not now |
+|---|---|---|---|
+| CP-16 | `xlsx@0.18.5` carries 2 high advisories (prototype pollution, ReDoS) | `package.json:34` | **No fix exists.** 0.18.5 is the latest version published to the public npm registry; the maintainer ships patches only via a self-hosted registry. Resolving it means changing registry or changing library — a decision, not a fix |
+| CP-21 | The whole Playwright suite is one spec, `tests/home.spec.ts` | `tests/` | Effort L. There is no regression net here at all, which is why every batch above had to carry its own ad-hoc verification |
+| CP-24 | The session lives in `localStorage`, readable by any XSS — 18 call sites even after CP-13 centralised the auth path | `grep -r "localStorage\." app layout lib adapter` | Architectural. Moving to httpOnly cookies needs coordinated API work (CORS credentials, CSRF) and is a rewrite of the auth flow, which the brief prohibits |
+| — | `prettier@2.8.8` → 3.x | `package.json:42` | Prettier 3 changes defaults (trailing commas). The bump is one line; the diff is every file in the repo. That is exactly the "reformateo global" the brief prohibits |
+
+---
+
+## 4. Merge order
+
+The batches are stacked, not independent. Merge in this order:
+
+```
+fix/cpanel-http          (pass 1, consolidated — 8 commits)
+  └─ fix/cpanel-session
+       └─ fix/cpanel-deps
+            └─ fix/cpanel-cleanup2
+                 └─ deps/cpanel-jspdf-major
+```
+
+`docs/audit-pass-2` (this file) branches off `fix/cpanel-http` and can merge at
+any point. `fix/cpanel-cleanup` (`fcdae32`) is an ancestor of `fix/cpanel-http`,
+not a separate PR.
+
+`deps/cpanel-jspdf-major` is deliberately last and deliberately alone: the brief
+requires every MAJOR dependency bump to be approved as its own batch.
+
+### Deviation from the brief
+
+Phase 7 asked for `git worktree add`. A fresh worktree has no `node_modules`, and
+installing one under the pnpm version mismatch described at the top would
+regenerate the lockfile. Branches in the main working tree were used instead, so
+"one batch = one branch" still holds.
+
+---
+
+## 5. Recommendations for the next pass
+
+1. **Pin `packageManager: "pnpm@10.x"` in `package.json`.** Nothing records which
+   pnpm this lockfile belongs to, so anyone on pnpm 11 rewrites it wholesale on
+   their first install. One line, and it prevents a whole category of accidental
+   dependency churn. The same applies to the API repo.
+2. **Decide what to do about `xlsx` (CP-16).** It is a direct production
+   dependency with two open highs and no published fix. The realistic options are
+   pointing at the maintainer's own registry or migrating the export path to
+   `exceljs`. Leaving it undecided means the advisory count never reaches zero.
+3. **Build a real test net (CP-21).** One Playwright spec is not a regression
+   net; every fix in this pass had to invent its own verification. The auth flow
+   rewritten in CP-13 is the first thing that deserves one — token expiry,
+   concurrent refresh, and refresh failure are exactly the paths a manual review
+   will not catch.


### PR DESCRIPTION
Adds `docs/audit-2026-08.md`, the report the other PRs in this stack reference by id. Its counterpart lives in the API repo at the same path.

Audit pass 1 left no report committed anywhere. That is why its eight commits sat unmerged and unexplained, and it is why this one is committed rather than left in a chat log.

Contents:
- **§1** every finding with its evidence as `file:line` or commit SHA — pass 1 carried over, plus the 12 new ones (CP-13..CP-27).
- **§2** what each batch fixed and how it was actually verified, with the real advisory delta measured by `pnpm audit`: **130 → 36** vulnerabilities, **4 critical → 0**. Includes a written correction to the original CP-14 triage, which targeted a Next version that was not high enough.
- **§3** what was deliberately left out and why — including **CP-16 (`xlsx`), which has no fix at all**: 0.18.5 is the latest version on the public npm registry, and the maintainer ships patches only through a self-hosted one. That is a decision for you, not a fix.
- **§4** the merge order, because the branches are a stack and not independent PRs.
- **§5** three recommendations for the next pass.

Written in English to match the existing `docs/` folder and the commit history.

---

**Stack:** base is `fix/cpanel-http`. This PR touches only `docs/` and can merge at any point in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
